### PR TITLE
fix import location on README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A lightweight utility that wraps custom elements ("web components") so they can 
 ## Usage
 
 ```jsx
-import wrapCustomElement from '@shoelace/react-wrapper';
+import wrapCustomElement from '@shoelace-style/react-wrapper';
 
 const ShoelaceButton = wrapCustomElement('sl-button');
 


### PR DESCRIPTION
Just a tiny tweak!

Failed to import when I went to check this out, discovered it's under the `@shoelace-style` org 😄 